### PR TITLE
fix unittest

### DIFF
--- a/src/drepl/interpreter.d
+++ b/src/drepl/interpreter.d
@@ -122,26 +122,29 @@ private:
         return !hasErr;
     }
 
-    unittest
+    static if (is(Engine == EchoEngine))
     {
-        auto intp = interpreter(echoEngine());
-        assert(intp.classify("3+2") == Kind.Expr);
-        // only single expressions
-        assert(intp.classify("3+2 foo()") == Kind.Error);
-        assert(intp.classify("3+2;") == Kind.Stmt);
-        // multiple statements
-        assert(intp.classify("3+2; foo();") == Kind.Stmt);
-        assert(intp.classify("struct Foo {}") == Kind.Decl);
-        // multiple declarations
-        assert(intp.classify("void foo() {} void bar() {}") == Kind.Decl);
-        // can't currently mix declarations and statements
-        assert(intp.classify("void foo() {} foo();") == Kind.Error);
-        // or declarations and expressions
-        assert(intp.classify("void foo() {} foo()") == Kind.Error);
-        // or statments and expressions
-        assert(intp.classify("foo(); foo()") == Kind.Error);
+        unittest
+        {
+            auto intp = interpreter(echoEngine());
+            assert(intp.classify("3+2") == Kind.Expr);
+            // only single expressions
+            assert(intp.classify("3+2 foo()") == Kind.Error);
+            assert(intp.classify("3+2;") == Kind.Stmt);
+            // multiple statements
+            assert(intp.classify("3+2; foo();") == Kind.Stmt);
+            assert(intp.classify("struct Foo {}") == Kind.Decl);
+            // multiple declarations
+            assert(intp.classify("void foo() {} void bar() {}") == Kind.Decl);
+            // can't currently mix declarations and statements
+            assert(intp.classify("void foo() {} foo();") == Kind.Error);
+            // or declarations and expressions
+            assert(intp.classify("void foo() {} foo()") == Kind.Error);
+            // or statments and expressions
+            assert(intp.classify("foo(); foo()") == Kind.Error);
 
-        assert(intp.classify("import std.stdio;") == Kind.Decl);
+            assert(intp.classify("import std.stdio;") == Kind.Decl);
+        }
     }
 
     Engine _engine;
@@ -152,6 +155,12 @@ Interpreter!Engine interpreter(Engine)(return scope Engine e) if (isEngine!Engin
 {
     // workaround Issue 18540
     return Interpreter!Engine(() @trusted { return move(e); }());
+}
+
+unittest
+{
+    // test instantiated
+    auto i = interpreter(dmdEngine());
 }
 
 unittest


### PR DESCRIPTION
I found a unittest inside `Interpreter` template can cause compiler error when I built drepl with unittest or used as a library. The problem is comparison between `Interpreter!EchoEngine.Kind` and `Interpreter!(<Instantiated Type>).Kind` in the unittest.

For example, when I instantiated `Interpreter!DMDEngine` inside unittest caused following compiler error.
```
src/drepl/interpreter.d(129,16): Error: Comparison between different enumeration types Kind and Kind; If this behavior is intended consider using std.conv.as
OriginalType
src/drepl/interpreter.d(131,16): Error: Comparison between different enumeration types Kind and Kind; If this behavior is intended consider using std.conv.as
OriginalType
src/drepl/interpreter.d(132,16): Error: Comparison between different enumeration types Kind and Kind; If this behavior is intended consider using std.conv.as
OriginalType
src/drepl/interpreter.d(134,16): Error: Comparison between different enumeration types Kind and Kind; If this behavior is intended consider using std.conv.as
OriginalType
src/drepl/interpreter.d(135,16): Error: Comparison between different enumeration types Kind and Kind; If this behavior is intended consider using std.conv.as
OriginalType
src/drepl/interpreter.d(137,16): Error: Comparison between different enumeration types Kind and Kind; If this behavior is intended consider using std.conv.asOriginalType
src/drepl/interpreter.d(139,16): Error: Comparison between different enumeration types Kind and Kind; If this behavior is intended consider using std.conv.asOriginalType
src/drepl/interpreter.d(141,16): Error: Comparison between different enumeration types Kind and Kind; If this behavior is intended consider using std.conv.asOriginalType
src/drepl/interpreter.d(143,16): Error: Comparison between different enumeration types Kind and Kind; If this behavior is intended consider using std.conv.asOriginalType
src/drepl/interpreter.d(145,16): Error: Comparison between different enumeration types Kind and Kind; If this behavior is intended consider using std.conv.asOriginalType
src/drepl/interpreter.d(152,1): Error: template instance `drepl.interpreter.Interpreter!(DMDEngine)` error instantiating
src/drepl/interpreter.d(160,25):        instantiated from here: interpreter!(DMDEngine)
```

Therefore, I propose adding `static if` to limit the unittest instantiation only with `EchoEngine`.