### PR TITLE
Add ldc to the supported compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: d
 d:
   - dmd
+  - ldc
+
 sudo: false
 
 install:

--- a/dub.json
+++ b/dub.json
@@ -4,7 +4,9 @@
     "copyright": "Copyright © 2014-2016, DREPL team",
     "license": "BSL-1.0",
     "authors": ["Martin Nowak"],
-    "lflags-linux-dmd": ["-l:libphobos2.so", "-ldl"],
+    "lflags-linux-dmd": ["-l:libphobos2.so"],
+    "lflags-linux-ldc": ["-l:libphobos2-ldc-shared.so", "-l:libdruntime-ldc-shared.so"],
+    "lflags-linux": ["-ldl"],
     "targetPath": "bin/",
     "configurations": [
         {


### PR DESCRIPTION
This PR will add support for LDC compiler. I'm not quite sure if it's better to refactor DMD Engine to be widely supported for every D compiler. Currently `ldmd` supports arguments of `dmd` using `ldc`.

Fixes #75 .